### PR TITLE
Fix: `value` won't be parsed when `default` presents and `value` is an empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const env = {
     TOKEN: 'token_keyboard_cat',
     NODE_ENV: 'development',
     apiKey: 'api_key_keyboard_dog'
-}
+};
 ```
 
 Additionally, this `env` has static type like:
@@ -87,7 +87,7 @@ Throws: `Error` object that tells us all environment variables missing.
 interface Option {
     default?: any;
     from?: string;
-    parse?(src): any
+    parse?(src: string): any;
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export function readenv<
     const errs = [] as Error[];
 
     for (const key in options) {
+        if (!hasOwn(options, key)) continue;
         const option = options[key];
         const value = process.env[options[key]['from'] ?? key];
         if (hasDefault(option))
@@ -54,6 +55,10 @@ interface OptionParse<P> extends OptionBase {
 function hasParse(option: OptionBase): option is OptionParse<any> {
     return 'parse' in option;
 }
+
+const hasOwn =
+    (Object as any).hasOwn ??
+    Object.prototype.hasOwnProperty.call.bind(Object.prototype.hasOwnProperty);
 
 /**
  * specifies how to read variable. one `Option` per one variable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 export function readenv<
     T extends {
-        [K in string]: Option<any, any>;
+        [key: string]: Option<any, any>;
     }
 >(options: T) {
     const env = {} as {
@@ -91,22 +91,23 @@ let formatList = (list: Iterable<string>): string => {
 };
 
 /**
- * specifies how to read variable. one `Option` per one variable.
+ * Specifies how a variable should be read.
+ * A single `Option` should be provided per one variable.
  */
 interface Option<D, P> extends OptionBase {
     /**
-     * default value used when variable was not found.
-     * if omitted throws error if variable was not found.
+     * The default value used when a variable was not found.
+     * If omitted, throws an error if the variable was not found.
      */
     default?: D;
     /**
-     * alternative variable name.
-     * if omitted use property name of `options`.
+     * The variable name to be read from `process.env`.
+     * If omitted, uses the property name of `options`.
      */
     from?: string;
     /**
-     * parser used after value was read.
-     * if omitted returns string value.
+     * The parser for transforming the value after reading.
+     * If omitted, returns a string value.
      */
     parse?(src: string): P;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function hasParse(option: OptionBase): option is OptionParse<any> {
 
 const hasOwn =
     (Object as any).hasOwn ??
-    Object.prototype.hasOwnProperty.call.bind(Object.prototype.hasOwnProperty);
+    Function.call.bind(Object.prototype.hasOwnProperty);
 
 let formatList = (list: Iterable<string>): string => {
     const listFormatter = new ((Intl as any).ListFormat ??

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export function readenv<
         const value = process.env[options[key]['from'] ?? key];
         if (hasDefault(option))
             env[key] = hasParse(option)
-                ? value
+                ? value !== undefined
                     ? option.parse(value)
                     : option.default
                 : value ?? option.default;


### PR DESCRIPTION
……などを色々弄りました。今更弄る理由は分かりません。（プルリクを開けすぎないようあえて分けませんでした）
最初のコミットがメインで他のはついついやってしまった感じかもしれません。
ちなみに `README.md` と `.prettierrc` をセーブする際にはフォーマットされてしまいます。特に `README.md` には trailing comma が追加され、それをコミットするかどうかちょっと迷いました。